### PR TITLE
[prettier] Skip lerna.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist/
 generated/
 pnpm-lock.yaml
+lerna.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
 
   examples/example-ts:
     specifiers:
-      sandbar: 0.1.0-alpha.2
+      sandbar: ^0.1.0-alpha.3
     dependencies:
       sandbar: link:../../packages/sandbar
 


### PR DESCRIPTION
```console
$ lerna version
```

edits the `lerna.json` file in a way that prettier is not happy with. so we skip lerna.json from prettier.